### PR TITLE
Fix run_query for empty params

### DIFF
--- a/db_utils.py
+++ b/db_utils.py
@@ -30,5 +30,12 @@ def list_tables(schema: str = "public") -> pd.DataFrame:
 
 
 def run_query(sql: str, **params) -> pd.DataFrame:
-    """Helper to run parameterised SQL and return DataFrame."""
-    return pd.read_sql(sql, get_engine(), params=params)
+    """Run parameterised SQL and return a DataFrame.
+
+    Pandas/SQLAlchemy will raise a ``TypeError`` when an empty dictionary is
+    passed as ``params`` even for queries that do not use parameters.  To avoid
+    this, ``params`` is only supplied when it contains values.
+    """
+    if params:
+        return pd.read_sql(sql, get_engine(), params=params)
+    return pd.read_sql(sql, get_engine())


### PR DESCRIPTION
## Summary
- avoid passing an empty `params` dictionary to `pandas.read_sql`

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_686f4e5dffc4832d838872147b1be45f